### PR TITLE
Simplified commands and some queries in service

### DIFF
--- a/src/main/java/at/saith/twasi/cmd/TimerAddCommand.java
+++ b/src/main/java/at/saith/twasi/cmd/TimerAddCommand.java
@@ -53,7 +53,7 @@ public class TimerAddCommand extends TwasiSubCommand {
 
             return false;
         } else {
-            event.reply(renderer.render("timer.add.syntax"));
+            super.handle(event);
             return false;
         }
     }

--- a/src/main/java/at/saith/twasi/cmd/TimerCommand.java
+++ b/src/main/java/at/saith/twasi/cmd/TimerCommand.java
@@ -25,13 +25,6 @@ public class TimerCommand extends StructuredPluginCommand {
     }
 
     @Override
-    protected boolean handle(TwasiCustomCommandEvent event) {
-        TranslationRenderer renderer = event.getRenderer();
-        event.reply(renderer.render("timer.syntax"));
-        return true;
-    }
-
-    @Override
     public String getCommandName() {
         return "timer";
     }

--- a/src/main/java/at/saith/twasi/cmd/TimerDeleteCommand.java
+++ b/src/main/java/at/saith/twasi/cmd/TimerDeleteCommand.java
@@ -40,7 +40,7 @@ public class TimerDeleteCommand extends TwasiSubCommand {
 
             return false;
         } else {
-            event.reply(renderer.render("timer.delete.syntax"));
+            super.handle(event);
             return false;
         }
     }

--- a/src/main/java/at/saith/twasi/cmd/TimerEnableCommand.java
+++ b/src/main/java/at/saith/twasi/cmd/TimerEnableCommand.java
@@ -21,7 +21,7 @@ public class TimerEnableCommand extends TwasiSubCommand {
         return handleEnableCommand(event);
     }
 
-    public static boolean handleEnableCommand(TwasiStructuredCommandEvent event) {
+    static boolean handleEnableCommand(TwasiStructuredCommandEvent event) {
         TranslationRenderer renderer = event.getRenderer();
         TimerService service = ServiceRegistry.get(TimerService.class);
         if (event.hasArgs() && event.getArgs().size() == 1) {

--- a/src/main/java/at/saith/twasi/cmd/TimerListCommand.java
+++ b/src/main/java/at/saith/twasi/cmd/TimerListCommand.java
@@ -38,7 +38,7 @@ public class TimerListCommand extends TwasiSubCommand {
             }
             return true;
         } else {
-            event.reply(renderer.render("timer.list.syntax"));
+            super.handle(event);
         }
         return false;
     }


### PR DESCRIPTION
If you don't override the handle() method in TwasiSubCommands they automatically render and send the command's syntax key (if it's present in the translation files).

Also please keep all methods of a service private or package-private that don't aim to provide any plugin specific features to other plugins (commandExists() in this case).

I also simplified the commandExists method using java streams to increase performance.